### PR TITLE
Making photonSymm only run the dipole directions

### DIFF
--- a/xanes_bench/OCEAN/makeOceanInputs.py
+++ b/xanes_bench/OCEAN/makeOceanInputs.py
@@ -94,25 +94,27 @@ def makeOcean( mpid, atoms: Atoms, params: dict ):
     # New total weight for the quadrupole terms
     totalweight = 0
     for photon in ph:
-        for quad in photon["quad"]:
-            totalweight += quad[3]
+        if 'quad' in photon:
+            for quad in photon["quad"]:
+                totalweight += quad[3]
 
     for photon in ph:
-        for quad in photon["quad"]:
-            photonCount += 1 
-            dir1 = photon["dipole"][0:3]
-            dir2 = quad[0:3]
-            weight = quad[3] / totalweight
-            mode = "quad"
+        if 'quad' in photon:
+            for quad in photon["quad"]:
+                photonCount += 1 
+                dir1 = photon["dipole"][0:3]
+                dir2 = quad[0:3]
+                weight = quad[3] / totalweight
+                mode = "quad"
 
-            with open( folder / ("photon%d" % (photonCount )), "w" ) as f:
-                f.write( mode +"\n" )
-                f.write( "cartesian %f %f %f \n" % (dir1[0], dir1[1], dir1[2] ) )
-                f.write( "end\n" )
-                f.write( "cartesian %f %f %f \n" % (dir2[0], dir2[1], dir2[2] ) )
-                f.write( "end\n" )
-                f.write( "4966\n" )  ### NEED TO FIX THIS (probably by moving it to a lookup table inside OCEAN)
-                f.write( str(weight ) + "\n" )
-                f.close
+                with open( folder / ("photon%d" % (photonCount )), "w" ) as f:
+                    f.write( mode +"\n" )
+                    f.write( "cartesian %f %f %f \n" % (dir1[0], dir1[1], dir1[2] ) )
+                    f.write( "end\n" )
+                    f.write( "cartesian %f %f %f \n" % (dir2[0], dir2[1], dir2[2] ) )
+                    f.write( "end\n" )
+                    f.write( "4966\n" )  ### NEED TO FIX THIS (probably by moving it to a lookup table inside OCEAN)
+                    f.write( str(weight ) + "\n" )
+                    f.close
 
       

--- a/xanes_bench/Xspectra/makeXspectraInputs.py
+++ b/xanes_bench/Xspectra/makeXspectraInputs.py
@@ -112,7 +112,7 @@ def makeXspectra( mpid, unitCell: Atoms, params: dict ):
                              symprec=0.1, angle_tolerance=15)
     equiv = symm['equivalent_atoms']
 
-    use_photonSymm = False
+    use_photonSymm = True
     ph = []
     if use_photonSymm:
         photonSymm(atoms, us, ph, params['photonOrder'])
@@ -233,27 +233,29 @@ def makeXspectra( mpid, unitCell: Atoms, params: dict ):
           # New total weight for the quadrupole terms
           totalweight = 0
           for photon in ph:
-              for quad in photon["quad"]:
-                  totalweight += quad[3]
+              if 'quad' in photon:
+                  for quad in photon["quad"]:
+                      totalweight += quad[3]
 
           for photon in ph:
-              for quad in photon["quad"]:
-                  photonCount += 1
-                  dir1 = photon["dipole"][0:3]
-                  dir2 = quad[0:3]
-                  weight = quad[3] * us[i] / totalweight
-                  mode = "quadrupole"
-                  xanesfolder = subfolder / ("%s%d" % (mode, photonCount))
-                  xanesfolder.mkdir(parents=True, exist_ok=True)
-                  # fo
-                  with open(xanesfolder / "xanes.in", "w") as f:
+              if 'quad' in photon:
+                  for quad in photon["quad"]:
+                      photonCount += 1
+                      dir1 = photon["dipole"][0:3]
+                      dir2 = quad[0:3]
+                      weight = quad[3] * us[i] / totalweight
+                      mode = "quadrupole"
+                      xanesfolder = subfolder / ("%s%d" % (mode, photonCount))
+                      xanesfolder.mkdir(parents=True, exist_ok=True)
+                      # fo
+                      with open(xanesfolder / "xanes.in", "w") as f:
+                              f.write(xinput(mode, iabs[i], dir1,
+                                                   dir2, xsJSON['XS']))
+
+                      with open(xanesfolder / "xanes_.in", "w") as f:
                           f.write(xinput(mode, iabs[i], dir1,
-                                               dir2, xsJSON['XS']))
+                                         dir2,  xsJSON['XS'], plot=True))
 
-                  with open(xanesfolder / "xanes_.in", "w") as f:
-                      f.write(xinput(mode, iabs[i], dir1,
-                                     dir2,  xsJSON['XS'], plot=True))
-
-                  with open(xanesfolder / "weight.txt", "w") as f:
-                      f.write( str(weight) + "\n" )
+                      with open(xanesfolder / "weight.txt", "w") as f:
+                          f.write( str(weight) + "\n" )
 

--- a/xanes_bench/photonSym.py
+++ b/xanes_bench/photonSym.py
@@ -80,6 +80,10 @@ def photonSymm( atoms: Atoms, uniqueSites: dict, photons: list, order=4 ):
 
 
     print( uniqueSites )
+    photons.append( { "dipole": [1,0,0,1] } )
+    photons.append( { "dipole": [0,1,0,1] } )
+    photons.append( { "dipole": [0,0,1,1] } )
+    return
 
 
     ohList = []


### PR DESCRIPTION
This shouldn't change the results, but it moves the photon direction generation for Xspectra back to the photonSymm routine. This way we have a single point of control for both OCEAN and XSpectra