### PR TITLE
Set exciting default cards

### DIFF
--- a/lightshow/parameters/exciting.py
+++ b/lightshow/parameters/exciting.py
@@ -133,7 +133,7 @@ class EXCITINGParameters(MSONable, _BaseParameters):
         name="EXCITING",
     ):
         # Default cards
-        self._cards = EXCITING_DEFAULT_CARDS
+        self._cards = cards
         # Update speciespath
         self._species_path = species_path
         self._cards["structure"]["speciespath"] = self._species_path


### PR DESCRIPTION
This pull request fixes a small bug in the initialization of the EXCITINGParameters:

Previously, the input parameter `cards` was never actually referenced. Instead, the EXCITING_DEFAULT_CARDS was stored as a class variable. 

With this pull request, the `cards` input parameter defaults to EXCITING_DEFAULT_CARDS, but can also be set manually.