### PR TITLE
Add Site Multiplicities to Structure Specific Metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+.vscode/settings.json

--- a/lightshow/_tests/test_metadata.py
+++ b/lightshow/_tests/test_metadata.py
@@ -35,5 +35,5 @@ def test_multiplicipty_writing(database_from_file, tmp_path):
     with open(metadata_fn) as f:
         d_metadata = json.load(f)
     assert "multiplicities" in d_metadata
-    i_site, n_multi = 2, 4
-    assert d_metadata[i_site] == n_multi
+    i_site, n_multi = "2", 4
+    assert d_metadata["multiplicities"][i_site] == n_multi

--- a/lightshow/_tests/test_metadata.py
+++ b/lightshow/_tests/test_metadata.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+from lightshow.parameters.feff import FEFFParameters
+
+
+def test_multiplicipty_writing(database_from_file, tmp_path):
+    target = Path(tmp_path) / Path("multi") / Path("destination")
+    target.mkdir(exist_ok=True, parents=True)
+    R = 10.0
+    feff_parameters = FEFFParameters(
+        cards={
+            "S02": "0",
+            "COREHOLE": "RPA",
+            "CONTROL": "1 1 1 1 1 1",
+            "XANES": "4 0.04 0.1",
+            "SCF": "7.0 0 100 0.2 3",
+            "FMS": "9.0 0",
+            "EXCHANGE": "0 0.0 0.0 2",
+            "RPATH": "-1",
+        },
+        edge="K",
+        radius=R - 1.0,
+        spectrum="XANES",
+        name="FEFF",
+    )
+    database_from_file.write(
+        target,
+        absorbing_atoms="all",
+        options=[feff_parameters],
+        write_unit_cells=True,
+        pbar=False,
+    )
+    metadata_fn = target / Path("00000002") / Path("metadata.json")
+    with open(metadata_fn) as f:
+        d_metadata = json.load(f)
+    assert "multiplicities" in d_metadata
+    i_site, n_multi = 2, 4
+    assert d_metadata[i_site] == n_multi

--- a/lightshow/_tests/test_metadata.py
+++ b/lightshow/_tests/test_metadata.py
@@ -31,9 +31,14 @@ def test_multiplicipty_writing(database_from_file, tmp_path):
         write_unit_cells=True,
         pbar=False,
     )
-    metadata_fn = target / Path("00000002") / Path("metadata.json")
-    with open(metadata_fn) as f:
-        d_metadata = json.load(f)
-    assert "multiplicities" in d_metadata
-    i_site, n_multi = "2", 4
-    assert d_metadata["multiplicities"][i_site] == n_multi
+    for k, v in database_from_file.metadata.items():
+        metadata_fn = target / Path(k) / Path("metadata.json")
+        with open(metadata_fn) as f:
+            d_metadata = json.load(f)
+        prim_meta = v["primitive"]
+        for i_site, n_multi in zip(
+            prim_meta["sites"], prim_meta["multiplicities"]
+        ):
+            i_site = str(i_site)
+            assert "multiplicities" in d_metadata
+            assert d_metadata["multiplicities"][i_site] == n_multi

--- a/lightshow/database.py
+++ b/lightshow/database.py
@@ -351,6 +351,14 @@ class Database(MSONable):
             fname = Path(root) / key / "metadata.json"
             origin = str(Path(metadata["origin"]).resolve())
             new_metadata = {"origin": origin}
+            multiplicities = {
+                i_site: n_multi
+                for i_site, n_multi in zip(
+                    metadata["primitive"]["sites"],
+                    metadata["primitive"]["multiplicities"],
+                )
+            }
+            new_metadata["multiplicities"] = multiplicities
             with open(fname, "w") as outfile:
                 json.dump(new_metadata, outfile, indent=4, sort_keys=True)
 


### PR DESCRIPTION
The site multiplicities are added as a dictionary, mapping a site index into its multiplicity, to the metadata.json file in each structure folder.