### PR TITLE
Fixes to respond to breaking API changes in dependencies

### DIFF
--- a/lightshow/ai/xas_ui.py
+++ b/lightshow/ai/xas_ui.py
@@ -115,7 +115,11 @@ def update_structure_by_mpid(search_mpid: str, el_type) -> Structure:
     
     with MPRester() as mpr:
         st = mpr.get_structure_by_material_id(search_mpid)
+        if not isinstance(st, Structure):
+            raise Exception("mp_api MPRester.get_structure_by_material_id did not return a pymatgen \"Structure\" object. This has been observed to occur when using an outdated version of mp_api with a more recent version of emmet-core. For now, please use the versions specified by LightShow's pyproject.toml")
+        
         print("Struct from material.")
+        
     st_dict = decorate_structure_with_xas(st, el_type)
     return st_dict, None, f"Current structure: {search_mpid}"
 
@@ -233,7 +237,7 @@ def serve():
               "please set your materials project API key to "
               "this environment variable before running this app")
         exit()
-    app.run_server(debug=False, port=8443, host='0.0.0.0')
+    app.run(debug=False, port=8443, host='0.0.0.0')
 
 if __name__ == "__main__":
     serve()

--- a/lightshow/ai/xas_ui.py
+++ b/lightshow/ai/xas_ui.py
@@ -237,7 +237,7 @@ def serve():
               "please set your materials project API key to "
               "this environment variable before running this app")
         exit()
-    app.run(debug=False, port=8443, host='0.0.0.0')
+    app.run(debug=False, port=8443, host='127.0.0.1')
 
 if __name__ == "__main__":
     serve()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,11 +64,15 @@ ai = [
     "matgl==0.8.5",
     "pydantic-core==2.23.4",
     "pydantic==2.9.2",
-    "pymatgen>=2024.3.1",
+    "pymatgen >=2024.3.1, <=2024.11.13",
     "torch==2.2.0",
     "torchdata==0.7.1",
     "gunicorn>=23.0.0",
-    "gevent>=25.5.0"
+    "gevent>=25.5.0",
+    "numpy<=1.26.4",
+    "ipython",
+    "emmet-core==0.84.3rc0",
+    "dash>=3.0"
 ]
 all = [
     "lightshow[test]",


### PR DESCRIPTION
- Changed app.run_server to app.run in response to API changes in Dash. Added dash>=3.0 dependency.
- Added upper bound on pymatgen and numpy versions, and added emmet-core dependency version to work around breaking API changes in torch (numpy) and mp_api (pymatgen,emmet).
- Added ipython as a dependency.

The complete installation has been tested in a new conda environment with Python 3.11.14