### PR TITLE
Adding Average Spectrum to Download

### DIFF
--- a/.codacyignore
+++ b/.codacyignore
@@ -1,1 +1,2 @@
 lightshow/ai/html/**
+docs/make.bat

--- a/lightshow/ai/xas_ui.py
+++ b/lightshow/ai/xas_ui.py
@@ -75,8 +75,12 @@ def download_xas_prediction(n_clicks, st_data, el_type):
     el, theory = el_type.split(' ')
     st = Structure.from_dict(st_data)
     d_xas = st_data['xas']
-    specs = np.stack([ene_grid[el]] + list(d_xas.values()))
-    site_idxs = ["Energy"] + [f'Atom #{int(i) + 1}' for i in d_xas.keys()]
+    specs_list = [ene_grid[el]] + list(d_xas.values())
+    avg_spec = np.stack(specs_list[1:]).mean(axis=0)
+    specs_list.append(avg_spec)
+    specs = np.stack(specs_list)
+    
+    site_idxs = ["Energy"] + [f'Atom #{int(i) + 1}' for i in d_xas.keys()] + ['Average']
     df = pd.DataFrame(specs, index=site_idxs)
     with tempfile.TemporaryDirectory() as td:
         tmpdir = pathlib.Path(td)


### PR DESCRIPTION
The average spectrum is appended to the CSV file now. The web engine doesn't analyze the symmetry of the structure. As such, the multipilicity of all the sites is 1. It is possible to add equivalent site analysis, but this is a slow function and will make the web page look unresponsive. @deyulu if you still prefer to add it, just let me know. Best, Xiaohui