### PR TITLE
Fix Wrong Identity Bug of Image Atoms

### DIFF
--- a/lightshow/ai/xas_ui.py
+++ b/lightshow/ai/xas_ui.py
@@ -211,8 +211,8 @@ def predict_site_specific_xas(sel, st_data, el_type) -> Structure:
         el_sel = sel[0]['tooltip'].split('(')[0].strip()
         pos_sel = np.array([float(x) for x in sel[0]['tooltip'].split('(')[1].split(')')[0].split(',')])
         frac_pos_sel = st.lattice.get_fractional_coords(pos_sel)
-        pos_sel = st.lattice.get_cartesian_coords(frac_pos_sel % 1.0)
-        dist = np.linalg.norm(st.cart_coords - pos_sel, axis=1)
+        dist = st.lattice.get_all_distances(frac_pos_sel, st.frac_coords)
+        dist = dist[0]
         i_site = np.argmin(dist)
         assert dist[i_site] < 0.01
         assert st[i_site].specie.symbol == el_sel

--- a/lightshow/ai/xas_ui.py
+++ b/lightshow/ai/xas_ui.py
@@ -206,6 +206,8 @@ def predict_site_specific_xas(sel, st_data, el_type) -> Structure:
         st = Structure.from_dict(st_data)
         el_sel = sel[0]['tooltip'].split('(')[0].strip()
         pos_sel = np.array([float(x) for x in sel[0]['tooltip'].split('(')[1].split(')')[0].split(',')])
+        frac_pos_sel = st.lattice.get_fractional_coords(pos_sel)
+        pos_sel = st.lattice.get_cartesian_coords(frac_pos_sel % 1.0)
         dist = np.linalg.norm(st.cart_coords - pos_sel, axis=1)
         i_site = np.argmin(dist)
         assert dist[i_site] < 0.01

--- a/lightshow/ai/xas_ui.py
+++ b/lightshow/ai/xas_ui.py
@@ -204,11 +204,12 @@ def predict_site_specific_xas(sel, st_data, el_type) -> Structure:
         fig = build_figure(spectrum, el_type, is_average=True, no_element=False, sel_mismatch=False)
     else:
         st = Structure.from_dict(st_data)
-        spheres = st._get_sites_to_draw()
-        spheres = list(spheres)
-        i_sphere = int(sel[0]['id'].split('--')[-1])
-        cur_sphere = spheres[i_sphere]
-        i_site = cur_sphere[0]
+        el_sel = sel[0]['tooltip'].split('(')[0].strip()
+        pos_sel = np.array([float(x) for x in sel[0]['tooltip'].split('(')[1].split(')')[0].split(',')])
+        dist = np.linalg.norm(st.cart_coords - pos_sel, axis=1)
+        i_site = np.argmin(dist)
+        assert dist[i_site] < 0.01
+        assert st[i_site].specie.symbol == el_sel
         if st[i_site].specie.symbol != element:
             fig = build_figure(None, el_type, is_average=False, no_element=False, sel_mismatch=True)
         else:


### PR DESCRIPTION
The bug has been fixed by mapping image atoms to the reference unitcell.